### PR TITLE
fix: file path containing spaces in rufo command not handled properly

### DIFF
--- a/src/rufo.ts
+++ b/src/rufo.ts
@@ -25,7 +25,7 @@ function runRufo(document: TextDocument) {
       const options: ExecOptions = { timeout: 3000 };
       if (cwd) options.cwd = cwd;
       const child = exec(
-        `rufo --filename ${document.fileName}`,
+        `rufo --filename '${document.fileName}'`,
         options,
         (error, stdout, stderr) => {
           if (!stderr && stdout && stdout.length > 0) {


### PR DESCRIPTION
Hello maintainers,

I've encountered an issue where executing the rufo command in the `vscode-rufo` extension failed when the file path contained spaces. For instance, a file was located at `~/Documents/GitHub/problem-solving/1. Two Sum/main.rb`, and running rufo directly on this file path broke due to misinterpretation by the command line.

![image](https://github.com/bessey/vscode-rufo/assets/92264237/0f7129c6-4dbd-406d-b866-1732f6807e60)


To resolve this issue, I've made a simple adjustment in the code. Specifically, I added single quotes around the file path parameter in the rufo command, ensuring that the command line interprets it as a single entity rather than separate parameters.

This change fixes the issue [`#24`](https://github.com/bessey/vscode-rufo/issues/24)

Thank you for considering this pull request. Let me know if you have any questions.

Best regards
